### PR TITLE
Open controller in normal tab and keep child windows on top

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,32 +1,29 @@
 chrome.action.onClicked.addListener(async () => {
-    const data = await chrome.storage.local.get(['controllerId']);
+    const data = await chrome.storage.local.get(['controllerTabId']);
 
-    if (data.controllerId) {
+    if (data.controllerTabId) {
         try {
-            await chrome.windows.get(data.controllerId);
-            await chrome.windows.update(data.controllerId, { focused: true });
+            const tab = await chrome.tabs.get(data.controllerTabId);
+            await chrome.windows.update(tab.windowId, { focused: true });
+            await chrome.tabs.update(tab.id, { active: true });
             return;
         } catch (e) {
-            // Controller window doesn't exist anymore
+            // Controller tab doesn't exist anymore
         }
     }
 
-    // Create new controller window
-    const window = await chrome.windows.create({
+    const tab = await chrome.tabs.create({
         url: 'controller.html',
-        type: 'popup',
-        width: 1200,
-        height: 900
+        active: true
     });
 
-    await chrome.storage.local.set({ controllerId: window.id });
+    await chrome.storage.local.set({ controllerTabId: tab.id });
 });
 
-chrome.windows.onRemoved.addListener(async (windowId) => {
-    const data = await chrome.storage.local.get(['controllerId', 'childIds']);
+chrome.tabs.onRemoved.addListener(async (tabId) => {
+    const data = await chrome.storage.local.get(['controllerTabId', 'childIds']);
 
-    if (windowId === data.controllerId) {
-        // Parent closed, close all children
+    if (tabId === data.controllerTabId) {
         if (data.childIds) {
             for (const id of data.childIds) {
                 try {
@@ -36,9 +33,14 @@ chrome.windows.onRemoved.addListener(async (windowId) => {
                 }
             }
         }
-        await chrome.storage.local.remove(['controllerId', 'childIds']);
-    } else if (data.childIds && data.childIds.includes(windowId)) {
-        // One of the children closed, we could potentially recreate it or just remove from list
+        await chrome.storage.local.remove(['controllerTabId', 'childIds']);
+    }
+});
+
+chrome.windows.onRemoved.addListener(async (windowId) => {
+    const data = await chrome.storage.local.get(['childIds']);
+
+    if (data.childIds && data.childIds.includes(windowId)) {
         const updatedChildIds = data.childIds.filter(id => id !== windowId);
         await chrome.storage.local.set({ childIds: updatedChildIds });
     }


### PR DESCRIPTION
### Motivation
- The controller UI should open as a regular browser tab instead of a popup so it stays inside the main Chrome window.
- Child ChatGPT windows must remain visually on top when the controller is moved so they are not hidden behind the controller.
- Use the controller tab lifecycle to clean up child windows when the controller is closed.

### Description
- Replace creation of a popup controller window with a normal tab and store its id in `controllerTabId` in `sw.js`, and activate/focus its window/tab when the action is clicked.
- Listen for `chrome.tabs.onRemoved` to detect controller tab close and close all `childIds`, and keep `chrome.windows.onRemoved` to update `childIds` when children are closed.
- In `controller.js` replace `chrome.windows.getCurrent()` usage with `getParentBounds()` computed from `window.screenX`, `window.screenY`, `window.innerWidth`, and `window.innerHeight`, including horizontal/vertical inset helpers.
- Add `BRING_CHILDREN_TO_FRONT` and refocus the top child after tiling in `tileWindows()` so children stay in front, and base layout calculations on the inner bounds.

### Testing
- No automated tests were run against the modified code.
- Changes were committed and the repository shows `controller.js` and `sw.js` modified; no further CI/lint/test output available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f010e6978833185652507bf09da92)