### PR TITLE
Add configurable target URL for panes (ChatGPT / Gemini)

### DIFF
--- a/controller.html
+++ b/controller.html
@@ -80,6 +80,34 @@
             color: white;
         }
 
+        .url-config {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            -webkit-app-region: no-drag;
+        }
+
+        .url-config label {
+            font-size: 12px;
+            color: #b0b0b0;
+        }
+
+        .url-config input {
+            background-color: #1f1f1f;
+            border: 1px solid #505050;
+            color: var(--text-color);
+            padding: 5px 8px;
+            border-radius: 6px;
+            font-size: 12px;
+            width: 220px;
+        }
+
+        .url-config input:focus {
+            outline: none;
+            border-color: var(--accent-color);
+            box-shadow: 0 0 0 1px var(--accent-color);
+        }
+
         .content {
             flex: 1;
             display: flex;
@@ -115,7 +143,7 @@
 
 <body>
     <div class="toolbar">
-        <button id="btn-refresh" title="Refresh all ChatGPT panes">
+        <button id="btn-refresh" title="Refresh all panes">
             <svg class="icons" viewBox="0 0 24 24">
                 <path
                     d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z" />
@@ -132,6 +160,12 @@
         <div style="width: 1px; height: 24px; background: #444; margin: 0 4px;"></div>
         <button id="layout-2x2" class="active">2 x 2</button>
         <button id="layout-1-3">1 + 3</button>
+        <div style="width: 1px; height: 24px; background: #444; margin: 0 4px;"></div>
+        <div class="url-config">
+            <label for="target-url">Target URL</label>
+            <input id="target-url" type="url" placeholder="https://chatgpt.com/" />
+            <button id="btn-save-url">Save</button>
+        </div>
 
         <button id="btn-close" class="close">
             <svg class="icons" viewBox="0 0 24 24">
@@ -143,8 +177,8 @@
     </div>
     <div class="content">
         <div class="status-overlay">
-            <h1>ChatGPT Multi-View Active</h1>
-            <p>Moving or resizing this window will tile the ChatGPT panes automatically.</p>
+            <h1>Multi-View Active</h1>
+            <p>Moving or resizing this window will tile the panes automatically.</p>
         </div>
     </div>
     <script src="controller.js"></script>


### PR DESCRIPTION
### Motivation
- Make the extension able to open different assistant pages (e.g. ChatGPT or Gemini) by letting the user configure the target URL instead of hard-coding ChatGPT.
- Persist the chosen URL across browser sessions using `chrome.storage` and keep the existing tiling/child-window behavior unchanged.

### Description
- Added a `Target URL` input and `Save` button in the controller toolbar and made on-screen copy pane-agnostic.
- Introduced `DEFAULT_TARGET_URL` and store `targetUrl` in `chrome.storage.local`, loading it at startup and defaulting to ChatGPT when missing or invalid.
- Use `targetUrl` when creating child windows and implement `retargetChildren()` to update existing child windows when the URL changes, with `normalizeTargetUrl()` to validate/normalize inputs.
- Wired UI interactions (`Enter` key and `Save` button) and updated event handlers to persist the setting and trigger retargeting.

### Testing
- Ran an automated Playwright script that rendered the updated `controller.html` and captured a screenshot of the controller UI, which succeeded and produced `artifacts/controller-ui.png`.
- No unit tests were present or run for storage/window APIs, and integration with a real Chrome extension runtime was not executed in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d710891fc8331a9ab3dac702c7cc4)