### PR TITLE
Fix controller child window sync after storage updates

### DIFF
--- a/controller.js
+++ b/controller.js
@@ -73,6 +73,13 @@ async function ensureChildren() {
     await tileWindows(true);
 }
 
+function handleChildIdsChange(newChildIds = []) {
+    childIds = newChildIds;
+    if (childIds.length < 4) {
+        ensureChildren();
+    }
+}
+
 function setLayout(layout) {
     currentLayout = layout;
     chrome.storage.local.set({ layout });
@@ -250,5 +257,13 @@ function getVerticalWindowInset() {
 function startPolling() {
     setInterval(tileWindows, POLL_INTERVAL);
 }
+
+chrome.storage.onChanged.addListener((changes, areaName) => {
+    if (areaName !== 'local' || !changes.childIds) {
+        return;
+    }
+
+    handleChildIdsChange(changes.childIds.newValue || []);
+});
 
 document.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
### Motivation
- The controller cached `childIds` at startup and did not react when the service worker or other parts of the extension updated storage after child windows were closed, leaving stale IDs and preventing missing panes from being recreated.

### Description
- Added `handleChildIdsChange(newChildIds)` to update the in-memory `childIds` and call `ensureChildren()` when the stored list is shorter than four to recreate missing popup panes.
- Added a `chrome.storage.onChanged` listener that watches `local` storage `childIds` changes and invokes the handler with the new value.
- The change keeps `controller.js` in sync with storage updates so tiling and pane recreation work reliably after windows are closed.

### Testing
- No automated tests were added or executed for this change.
- The change was committed and a PR was created for review; recommend running the extension manually or CI to validate runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69802ac1e0648331b002c7fc352ef9bb)